### PR TITLE
Fix to joystick emulation not working

### DIFF
--- a/nest/modules/input/joystick.lua
+++ b/nest/modules/input/joystick.lua
@@ -5,13 +5,13 @@ local keyboard = {}
 local bindings = {}
 
 function keyboard.init()
-    local bindings = require(path .. ".bindings")
+    local loadedBindings = require(path .. ".bindings")
 
-    for key, value in pairs(bindings.buttons) do
+    for key, value in pairs(loadedBindings.buttons) do
         bindings[value] = key
     end
 
-    for key, value in pairs(bindings.axes) do
+    for key, value in pairs(loadedBindings.axes) do
         bindings[value] = key
     end
 end


### PR DESCRIPTION
The variable `bindings` was re-declared inside `keyboard.init()`. All it ended up doing was assigning key-value pairs to that loaded `bindings` module inside the init function, instead of giving it to the `bindings` table used by `joystick.lua`.

This patch fixes it by simply renaming the `bindings` inside `keyboard.init()` into `loadedBindings`.

I was using Love2D 11.4 win64 for this.